### PR TITLE
   (Problem) Ballot allows to swap mining key to previously owned mining key

### DIFF
--- a/contracts/interfaces/IKeysManager.sol
+++ b/contracts/interfaces/IKeysManager.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.4.18;
 
 contract IKeysManager {
     address public masterOfCeremony;
-    address public votingContract;
     address public poaNetworkConsensus;
     uint256 public maxNumberOfInitialKeys;
     uint256 public initialKeysCount;


### PR DESCRIPTION
    (Solution) Add check down to 25 miningHistory to prevent from circulation loop problem that will allow a miner to double vote
